### PR TITLE
Multifile-Modus, Jahres-Aufteilung der Ausgabe + Doku/Cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,10 @@ Primary documentation (README.md) is written in **German**.
 
 ```
 dl-sd-card-abs-date/
-├── dl-sd-card-date.py          # Main script (~960 lines, single-file application)
+├── dl-sd-card-date.py          # Main script (~990 lines, single-file application)
 ├── dl-sd-card-date.yaml        # YAML configuration (all tunable parameters)
 ├── decentlab.py                # Decentlab API client (MIT License, Decentlab GmbH 2016)
+├── requirements.txt            # Dependency pins (pandas, numpy, requests, PyYAML)
 ├── README.md                   # Comprehensive documentation (German)
 ├── .gitignore                  # Standard Python gitignore
 ├── Input/                      # Input data directory
@@ -36,6 +37,10 @@ dl-sd-card-abs-date/
 
 Install dependencies:
 ```bash
+# All dependencies at once (includes optional requests + PyYAML):
+pip install -r requirements.txt
+
+# Or selectively:
 pip install pandas numpy
 # For API mode:
 pip install requests
@@ -43,7 +48,8 @@ pip install requests
 pip install pyyaml
 ```
 
-No `requirements.txt`, `setup.py`, or `pyproject.toml` exists. This is a single-file script, not a package.
+A `requirements.txt` (dependency pins with comments) exists. No `setup.py` or
+`pyproject.toml` exists — this is a single-file script, not a package.
 
 ## Running the Script
 

--- a/dl-sd-card-date.py
+++ b/dl-sd-card-date.py
@@ -361,7 +361,6 @@ def read_influx_files(influx_paths: List[Path]) -> pd.DataFrame:
         influx_col = col_map[col_def["sensor"]]
         vals = df[influx_col].astype(float).values
         q = _round_half_up(vals, col_def["decimals"])
-        col_name = f"val_q_{col_def['sd_index']}"
         q_arrays.append(q)
         dec_list.append(col_def["decimals"])
 


### PR DESCRIPTION
## Zusammenfassung

Zwei zusammengehörige Änderungen:

### 1. Neue Features

**`--multifile PATH`** — verarbeitet alle `*_SDCard_raw_*.csv` aus einem Verzeichnis.
- Jede Datei wird einzeln gegen die **Decentlab-API** gematcht; das **Auslesedatum** wird aus der letzten `YYYYMMDD`-Gruppe im Dateinamen abgeleitet (z. B. `SGS_SDCard_raw_20250816.csv` → 2025-08-16).
- Optional gemeinsame **Offline-Referenz** via `--influx-dir`.
- `segment_id`/`idx_sd_global` sind über alle Dateien hinweg eindeutig; Reports werden **vereint** geschrieben.

**`--split-by-year`** — schreibt `SD_absolute_<Jahr>.csv` je Kalenderjahr von `t_abs_utc` (undatierte Zeilen → `SD_absolute_undatiert.csv`). In jedem Modus nutzbar.

Typischer Aufruf:
```bash
python dl-sd-card-date.py --multifile Input/ --split-by-year
```

### 2. Doku-Aktualität & Cleanup (ursprünglicher Review-Befund)

- CLAUDE.md: `requirements.txt` im Baum/Install-Abschnitt ergänzt, Falschaussage „No requirements.txt … exists" korrigiert, Zeilenzahl aktualisiert.
- Ungenutzte Variable `col_name` in `read_influx_files` entfernt.
- Latenter Bug behoben: `read_sd_files_from_dir` vergab `segment_id`/`global_idx` pro Datei ab 0 (Kollision bei mehreren Dateien) → jetzt global eindeutig.

## Refactoring

- Matching/Fit/Apply pro Segment in `process_segments()` ausgelagert; Single-File-Pfad in `main()` nutzt diese Funktion ebenfalls (keine Verhaltensänderung).
- `_readout_date_from_name()` für Dateiname→Auslesedatum.
- `run_multifile()` für die Mehrdatei-Pipeline.

## Tests

- `python3 -m py_compile` → OK.
- Dateiname-Parsing geprüft (inkl. `…_19057_20250510` und ungültige Daten → None).
- Synthetischer **End-to-End-Offline-Lauf** über den Jahreswechsel 2023→2024: `--multifile` erzeugt global eindeutige Segmente (0/1) und vereinte Reports; `--split-by-year` liefert `SD_absolute_2023.csv` (nur 2023-Zeilen) und `SD_absolute_2024.csv` (nur 2024-Zeilen).
- Single-File-Pfad mit und ohne `--split-by-year` ohne Regression.
- Hinweis: kein Lauf gegen echte Decentlab-API (keine Credentials in dieser Umgebung).

https://claude.ai/code/session_01VFpszUU7wPaqvxR2ZRcine