### PR TITLE
feat: local config override via dl-sd-card-date.local.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Lokale Konfiguration mit Credentials (nicht committen)
+dl-sd-card-date.local.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,8 @@ No linting or formatting tools are configured. The `.gitignore` references `.ruf
 
 ## Configuration Parameters (dl-sd-card-date.yaml)
 
+**Local override:** `dl-sd-card-date.local.yaml` (gitignored) is loaded before `dl-sd-card-date.yaml` when present. Use it for credentials that must not be committed. Load order: `--config` flag > `.local.yaml` > `.yaml`.
+
 Key parameter groups:
 | Group | Examples | Purpose |
 |-------|----------|---------|
@@ -145,3 +147,4 @@ Timestamp, Timezone Offset, <device>.battery, <device>.sensirion-sht35-humidity,
 - The `Input/` directory contains real sensor data used for validation — do not modify or delete
 - Windows path compatibility (backslash handling) is intentionally maintained
 - `decentlab.py` is an external MIT-licensed file from Decentlab GmbH — prefer minimal modifications
+- `dl-sd-card-date.local.yaml` is gitignored and must never be created or written by AI assistants — it is for user credentials only

--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ python dl-sd-card-date.py --config my.yaml
 
 ### 2) Konfiguration (optional)
 
+#### Lokale Konfiguration mit Credentials (nicht committen)
+
+Das Script lädt automatisch `dl-sd-card-date.local.yaml` **vor** `dl-sd-card-date.yaml`, wenn
+die Datei vorhanden ist. Diese Datei ist in `.gitignore` eingetragen und eignet sich für
+API-Zugangsdaten, die nicht ins Repository gehören.
+
+Einmalig anlegen:
+```bash
+cp dl-sd-card-date.yaml dl-sd-card-date.local.yaml
+# Dann API_DOMAIN, API_KEY, DEVICE_ID in der .local.yaml eintragen
+```
+
+Ladereihenfolge: `--config`-Flag > `dl-sd-card-date.local.yaml` > `dl-sd-card-date.yaml`.
+
+---
+
 `dl-sd-card-date.yaml` (alle Werte optional; Defaults im Script):
 
 ```yaml

--- a/dl-sd-card-date.py
+++ b/dl-sd-card-date.py
@@ -174,8 +174,11 @@ def _apply_config(config_path: Optional[str]):
     """Lädt Config und setzt globale Variablen."""
     if not config_path:
         script_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+        local_yaml = script_dir / "dl-sd-card-date.local.yaml"
         default_yaml = script_dir / "dl-sd-card-date.yaml"
-        if default_yaml.exists():
+        if local_yaml.exists():
+            config_path = str(local_yaml)
+        elif default_yaml.exists():
             config_path = str(default_yaml)
         else:
             return


### PR DESCRIPTION
  ## Motivation

  API-Zugangsdaten (API_DOMAIN, API_KEY, DEVICE_ID) standen bisher nur in
  dl-sd-card-date.yaml, die committed und versioniert ist. Es gab keinen sicheren
  Weg, Credentials lokal zu hinterlegen, ohne sie versehentlich zu committen.

  ## Lösung

  - dl-sd-card-date.local.yaml wird automatisch vor dl-sd-card-date.yaml geladen
  - Die Datei ist in .gitignore eingetragen — versehentlicher Commit nicht möglich
  - Ladereihenfolge: --config-Flag > .local.yaml > .yaml
  - --config-Flag und öffentliche .yaml bleiben unverändert nutzbar

  ## Commits

  1. chore: gitignore local config override — Schutz zuerst
  2. feat: support local config override — 4-Zeilen-Änderung in _apply_config()
  3. docs: document local config override pattern — README.md + CLAUDE.md

  ## Test

  - git check-ignore -v dl-sd-card-date.local.yaml → Exit-Code 0 ✓
  - Manuell: .local.yaml mit abweichendem OUTPUT_DIR anlegen → Script nutzt diesen Wert
  - Ohne .local.yaml: Verhalten identisch zu vorher

  ---
  Sobald du den PR gemergt hast, kannst du dl-sd-card-date.local.yaml mit deinen Credentials anlegen — die Datei wird nie in einen Commit geraten.